### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -96,6 +96,9 @@
         <config-file target="*-Info.plist" parent="NSBluetoothPeripheralUsageDescription">
             <string>This app would like to scan for beacons while it is in use.</string>
         </config-file>
+        <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
+            <string>This app would like to scan for beacons while it is in background.</string>
+        </config-file>
         
     </platform>
 </plugin>


### PR DESCRIPTION
Add to the end of <platform name="ios"> for iOS 15 crashes
<config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
    <string>This app would like to scan for beacons while it is in background.</string>
</config-file>